### PR TITLE
create DemoPromise in Then instead of a Promise

### DIFF
--- a/demo_promise2_chaining.js
+++ b/demo_promise2_chaining.js
@@ -11,7 +11,7 @@ export class DemoPromise {
         this.promiseState = 'pending';
     }
     then(onFulfilled, onRejected) {
-        let returnValue = new Promise(); // [new]
+        let returnValue = new DemoPromise(); // [new]
         let self = this;
 
         let fulfilledTask;


### PR DESCRIPTION
Fix a minor issue in demo_promise2_chaining.js where we should create DemoPromise instead of Promise.
Thanks for your awesome code! It teaches me a lot what is going on under the hood of Promise!